### PR TITLE
Support error stacktrace

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,9 +1,13 @@
 package main
 
-import "log"
+import (
+	"log"
+
+	"github.com/juju/errors"
+)
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		log.Fatal(err)
+		log.Fatal(errors.ErrorStack(err))
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,8 @@ package main
 import (
 	"log"
 
+	"github.com/juju/errors"
+
 	"github.com/tiket-libre/canary-router/config"
 	"github.com/tiket-libre/canary-router/instrumentation"
 	"github.com/tiket-libre/canary-router/server"
@@ -29,12 +31,12 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		log.Fatalf("Can't read config: %v", err)
+		log.Fatalf("Can't read config: %v", errors.ErrorStack(err))
 	}
 
 	err := viper.Unmarshal(&appConfig)
 	if err != nil {
-		log.Fatalf("Unable to decode into config struct: %v", err)
+		log.Fatalf("Unable to decode into config struct: %v", errors.ErrorStack(err))
 	}
 }
 
@@ -44,12 +46,12 @@ var rootCmd = &cobra.Command{
 	Long:  `canary-router forwards HTTP request based on your custom logic`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := instrumentation.Initialize(appConfig.Instrumentation); err != nil {
-			return err
+			return errors.Trace(err)
 		}
 
 		server, err := server.NewServer(appConfig)
 		if err != nil {
-			return err
+			return errors.Trace(err)
 		}
 
 		return server.Run()

--- a/instrumentation/view.go
+++ b/instrumentation/view.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 
+	"github.com/juju/errors"
+
 	"github.com/tiket-libre/canary-router/config"
 
 	"contrib.go.opencensus.io/exporter/prometheus"
@@ -29,14 +31,14 @@ var (
 func Initialize(cfg config.InstrumentationConfig) error {
 
 	if err := view.Register(views...); err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	pe, err := prometheus.NewExporter(prometheus.Options{
 		Namespace: "canary_router",
 	})
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 
 	view.RegisterExporter(pe)
@@ -45,7 +47,7 @@ func Initialize(cfg config.InstrumentationConfig) error {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", pe)
 		if err := http.ListenAndServe(addr, mux); err != nil {
-			log.Fatalf("Failed to run Prometheus scrape endpoint: %v", err)
+			log.Fatalf("Failed to run Prometheus scrape endpoint: %v", errors.ErrorStack(err))
 		}
 	}()
 

--- a/proxy.go
+++ b/proxy.go
@@ -3,6 +3,8 @@ package canaryrouter
 import (
 	"net/http/httputil"
 	"net/url"
+
+	"github.com/juju/errors"
 )
 
 // Proxy holds the reference to instance of Main and Canary httputil.ReverseProxy
@@ -17,12 +19,12 @@ type Proxy struct {
 func BuildProxies(mainTargetURL, canaryTargetURL string) (*Proxy, error) {
 	proxyMain, err := newReverseProxy(mainTargetURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	proxyCanary, err := newReverseProxy(canaryTargetURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	proxies := &Proxy{
@@ -36,7 +38,7 @@ func BuildProxies(mainTargetURL, canaryTargetURL string) (*Proxy, error) {
 func newReverseProxy(target string) (*httputil.ReverseProxy, error) {
 	url, err := url.ParseRequestURI(target)
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 
 	return httputil.NewSingleHostReverseProxy(url), nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/juju/errors"
+
 	"github.com/tiket-libre/canary-router/config"
 
 	canaryrouter "github.com/tiket-libre/canary-router"
@@ -287,7 +289,7 @@ func setupThisRouterServer(t *testing.T, backendMainURL, backendCanaryURL string
 		}}
 	s, err := NewServer(c)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal(errors.ErrorStack(err))
 	}
 	s.sidecarHTTPClient = sidecarHTTPClient
 
@@ -297,7 +299,7 @@ func setupThisRouterServer(t *testing.T, backendMainURL, backendCanaryURL string
 func newRequest(method, url, body string) (*http.Request, error) {
 	req, err := http.NewRequest(method, url, strings.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, errors.Trace(err)
 	}
 	return req, nil
 }


### PR DESCRIPTION
It will give a helpful error message for finding the root cause of an error (with line number).
Example:
```shell
server_test.go:159: parse : empty url
                /Users/fahrihidayat/Projects/tiket-libre/canary-router/proxy.go:41: 
                /Users/fahrihidayat/Projects/tiket-libre/canary-router/proxy.go:22: 
                /Users/fahrihidayat/Projects/tiket-libre/canary-router/server/server.go:39: 
```